### PR TITLE
mainCaller simplified and preset number wrapped

### DIFF
--- a/DX7.scd
+++ b/DX7.scd
@@ -668,27 +668,23 @@ f = { arg x, y ,z; //y value, z cc no
 		{ vr[y + 128] = z }
 	)
 };
+
 //Creating a patch array from .afx file to prevent "unsaved file" error.
 r = File("DX7.afx".resolveRelative,"r");
 16384.do({arg item;
 	dx7patches[item] = r.getLine;
 });
 
-mainCaller = { arg x, y, z;
-	if(y > 0,{
-//		r = File("DX7.afx".resolveRelative,"r");
-		//r = File("/Users/EmanTnuocca/Desktop/3/DX7.afx","r");
-
-		g = dx7patches[z];
+mainCaller = { arg note, vel, preset;
+	if(vel > 0,{
+		var g = dx7patches[preset%16384];
 		145.do({arg item;
-			k = (g.at((item*2)) ++ g.at((item*2) + 1)).asInt;
+			var k = (g.at((item*2)) ++ g.at((item*2) + 1)).asInt;
 			f.value(cirklonCCparse[item][0],cirklonCCparse[item][1],k);
 			//~midiOutDX7.control(~cirklonCCparse[item][0],~cirklonCCparse[item][1],k);
-
 		});
 	});
-	noteParser.value(y, x)
-
+	noteParser.value(vel, note)
 };
 )
 


### PR DESCRIPTION
- mainCaller params has representative names
- Remove extra unused mainCaller comments
- Wrap the presets number between 0 and 16384 to prevent mistakes like the [issue 12](https://github.com/everythingwillbetakenaway/DX7-Supercollider/issues/12)